### PR TITLE
stopped content jumping

### DIFF
--- a/src/components/EventDetailPage.tsx
+++ b/src/components/EventDetailPage.tsx
@@ -24,7 +24,7 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
   const selectedEvent = events.find((event) => event.id === parseInt(eventId!));
   const [currentEvent, setCurrentEvent] = useState<any>(null);
   const eventCreator = selectedEvent?.cognitoUserId;
-  
+
   const [hostedBy, setHostedBy] = useState("Loading...");
   const [isAttending, setIsAttending] = useState(false);
   const [loggedInUser, setLoggedInUser] = useState<string | null>(null);
@@ -76,13 +76,13 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
             const session = await fetchAuthSession();
             const cognitoUserId = session?.tokens?.idToken?.payload?.sub;
             setLoggedInUser(cognitoUserId || null);
-            if (typeof(cognitoUserId) === "string") {
+            if (typeof (cognitoUserId) === "string") {
               const retrievedCreator = await fetchHostedBy(event.cognitoUserId);
-              if (typeof(retrievedCreator) === "string") {
-              setHostedBy(retrievedCreator);
+              if (typeof (retrievedCreator) === "string") {
+                setHostedBy(retrievedCreator);
+              }
             }
-          }
-            
+
             if (eventId && cognitoUserId) {
               const isUserAttending = await checkAttendance(
                 eventId,
@@ -169,7 +169,7 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
       <div className="flex justify-center py-8 px-4">
         <div className="w-full">
           <h1 className="text-3xl font-extrabold text-center mb-4">
-          {`${selectedEvent.street}, ${selectedEvent.city}, ${selectedEvent.state} ${selectedEvent.zip}`}
+            {`${selectedEvent.street}, ${selectedEvent.city}, ${selectedEvent.state} ${selectedEvent.zip}`}
           </h1>
           <div className="flex justify-center pb-8">
             <Map
@@ -179,12 +179,30 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
             />
           </div>
           <div className="flex flex-col md:flex-row items-center bg-white border border-gray-200 rounded-lg shadow-lg hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700 w-4/5 mx-auto h-[500px]"> {/* Fixed height added here */}
-            <img
-              className="object-cover w-full md:w-1/2 h-96 md:h-auto rounded-t-lg md:rounded-l-lg"
-              src={selectedEvent.image}
-              alt={selectedEvent.title}
-            />
-            <div className="flex flex-col justify-between p-6 leading-normal w-full md:w-1/2 text-center">
+            <div className="flex flex-col items-start ml-3 w-4/6">
+              <img
+                className="mt-10 ml-9 md:w-10/12 md:h-auto rounded-t-lg md:rounded-l-lg"
+                src={selectedEvent.image}
+                alt={selectedEvent.title}
+              />
+              <div className="min-h-40">
+                {showAttendees && (
+                  <div className="mt-4 ml-10 text-left overflow-auto max-h-32">
+                    <h3 className="text-xl font-bold mb-2">Attendees:</h3>
+                    {attendees.length > 0 ? (
+                      <ul className="list-disc list-inside">
+                        {attendees.map((username, index) => (
+                          <li key={index}>{username}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p>No attendees yet.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col mr-12 justify-between p-6 leading-normal w-full md:w-1/2 text-center">
               <h5 className="mb-2 text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
                 {`${selectedEvent.title}`}
               </h5>
@@ -198,7 +216,7 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
                 </p>
               )}
               <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
-                The event {selectedEvent.cancelled ? "is cancelled :\"": "is still on!"}
+                The event {selectedEvent.cancelled ? "is cancelled :\"" : "is still on!"}
               </p>
               <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
                 <b>Time of Event: </b>
@@ -206,7 +224,7 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
               </p>
               <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
                 <b>Hosted By: </b>
-                { hostedBy|| "Loading..." }
+                {hostedBy || "Loading..."}
               </p>
               <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
                 <b>Description: </b>
@@ -291,8 +309,8 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
                   {showAttendees ? "Hide Attendees" : "See Attendees"}
                 </button>
               </div>
-              {showAttendees && (
-                <div className="mt-4 text-left overflow-auto max-h-32"> {/* Limit height and allow scrolling */}
+              {/* {showAttendees && (
+                <div className="mt-4 text-left overflow-auto max-h-32"> 
                   <h3 className="text-xl font-bold mb-2">Attendees:</h3>
                   {attendees.length > 0 ? (
                     <ul className="list-disc list-inside">
@@ -304,7 +322,7 @@ const EventDetailPage: React.FC<EventDetailPageProps> = ({ events }) => {
                     <p>No attendees yet.</p>
                   )}
                 </div>
-              )}
+              )} */}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Changed the event detail page styling to prevent the image or text from jumping when "show attendees" is clicked